### PR TITLE
Adds non_resource_urls

### DIFF
--- a/internal/kubernetes/rbac/v1/role/rule/expand.go
+++ b/internal/kubernetes/rbac/v1/role/rule/expand.go
@@ -3,6 +3,7 @@ package rule
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 
+	"github.com/previousnext/terraform-provider-k8s/internal/interfaceutils"
 	"github.com/previousnext/terraform-provider-k8s/internal/kubernetes/rbac/v1/role/rule/apigroups"
 	"github.com/previousnext/terraform-provider-k8s/internal/kubernetes/rbac/v1/role/rule/resourcenames"
 	"github.com/previousnext/terraform-provider-k8s/internal/kubernetes/rbac/v1/role/rule/resources"
@@ -22,6 +23,10 @@ func Expand(in []interface{}) []rbacv1.PolicyRule {
 
 		if apiGroupsRaw, ok := value[FieldAPIGroups]; ok {
 			rules[key].APIGroups = apigroups.Expand(apiGroupsRaw.([]interface{}))
+		}
+
+		if nonResourceURLsRaw, ok := value[FieldNonResourceURLs]; ok {
+			rules[key].NonResourceURLs = interfaceutils.ExpandSlice(nonResourceURLsRaw.([]interface{}))
 		}
 
 		if resourcesRaw, ok := value[FieldResources]; ok {

--- a/internal/kubernetes/rbac/v1/role/rule/fields.go
+++ b/internal/kubernetes/rbac/v1/role/rule/fields.go
@@ -18,6 +18,8 @@ const (
 	FieldResourceNames = "resource_names"
 	// FieldVerbs is used to identify the verbs field.
 	FieldVerbs = "verbs"
+	// FieldNonResourceURLs is used to declare non resource paths eg. /metrics.
+	FieldNonResourceURLs = "non_resource_urls"
 )
 
 // Fields returns the fields for this package.
@@ -28,7 +30,14 @@ func Fields() *schema.Schema {
 		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				FieldAPIGroups:     apigroups.Fields(),
+				FieldAPIGroups: apigroups.Fields(),
+				FieldNonResourceURLs: &schema.Schema{
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
 				FieldResources:     resources.Fields(),
 				FieldResourceNames: resourcenames.Fields(),
 				FieldVerbs:         verbs.Fields(),

--- a/internal/kubernetes/rbac/v1/role/rule/flatten.go
+++ b/internal/kubernetes/rbac/v1/role/rule/flatten.go
@@ -13,6 +13,10 @@ func Flatten(in []rbacv1.PolicyRule) []interface{} {
 			row[FieldAPIGroups] = value.APIGroups
 		}
 
+		if len(value.NonResourceURLs) > 0 {
+			row[FieldNonResourceURLs] = value.NonResourceURLs
+		}
+
 		if len(value.Resources) > 0 {
 			row[FieldResources] = value.Resources
 		}


### PR DESCRIPTION
Adds the ability to do the following:

```
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: ClusterRole
metadata:
  name: prometheus
rules:
  - nonResourceURLs:
      - "/metrics"
    verbs: ["get"]
```